### PR TITLE
Add metrics selection to the interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ hidden/
 __pycache__/
 machine.pkl
 output.csv
-just-testing.py
+testing.py

--- a/automl.py
+++ b/automl.py
@@ -18,20 +18,21 @@ class Machine:
                 self.modelParams = prev.modelParams
                 self.modelName = prev.modelName
                 self.model = prev.model
+
                 self.transformer = prev.transformer
                 self.isClassifier = prev.isClassifier
                 self.isTrained = prev.isTrained
 
-    def learn(self, dataset_file, header_in_csv=False, verbose=True):
+    def learn(self, dataset_file, header_in_csv=False, metrics=None, verbose=True):
         dataset = pd.read_csv(dataset_file, header=(
             0 if header_in_csv else None))
 
         X = dataset.iloc[:, :-1]
         y = dataset.iloc[:, -1]
 
-        self.learnFromDf(X, y, verbose)
+        self.learnFromDf(X, y, metrics, verbose)
 
-    def learnFromDf(self, X, y, verbose=True):
+    def learnFromDf(self, X, y, metrics=None, verbose=True):
         self.isClassifier = isinstance(y[0], str)
 
         self.transformer = Transformer()

--- a/automl.py
+++ b/automl.py
@@ -2,6 +2,7 @@ import pandas as pd
 import joblib
 from automl_models_generation import generateModel
 from automl_transformer import Transformer
+from automl_metrics import isValidMetrics
 
 
 class Machine:
@@ -18,7 +19,6 @@ class Machine:
                 self.modelParams = prev.modelParams
                 self.modelName = prev.modelName
                 self.model = prev.model
-
                 self.transformer = prev.transformer
                 self.isClassifier = prev.isClassifier
                 self.isTrained = prev.isTrained
@@ -35,10 +35,15 @@ class Machine:
     def learnFromDf(self, X, y, metrics=None, verbose=True):
         self.isClassifier = isinstance(y[0], str)
 
+        if(not isValidMetrics(metrics, self.isClassifier)):
+            print("This metrics invalid")
+            return None
+
         self.transformer = Transformer()
         X_prep = self.transformer.fit_transform(X)
 
-        modelData = generateModel(X_prep, y, self.isClassifier, verbose)
+        modelData = generateModel(
+            X_prep, y, self.isClassifier, metrics, verbose)
 
         self.modelName = modelData['name']
         self.model = modelData['estimator']
@@ -74,9 +79,9 @@ class Machine:
         return y_pred_dataframe
 
     def learnAndPredict(self, train_set_file, prediction_features_file,
-                        output_file="output.csv", headers_in_csvs=False,
+                        output_file="output.csv", headers_in_csvs=False, metrics=None,
                         verbose=True):
-        self.learn(train_set_file, headers_in_csvs, verbose)
+        self.learn(train_set_file, headers_in_csvs, metrics, verbose)
         self.predict(prediction_features_file, output_file, headers_in_csvs)
 
     def saveMachine(self, output_file_name="machine.pkl"):

--- a/automl_metrics.py
+++ b/automl_metrics.py
@@ -1,0 +1,66 @@
+from typing import Union
+from sklearn.metrics import make_scorer
+
+classificationLibraryMetrics = set([
+    'accuracy',
+    'balanced_accuracy',
+    'average_precision',
+    'neg_brier_score',
+    'f1',
+    'f1_micro',
+    'f1_macro',
+    'f1_weighted',
+    'f1_samples',
+    'neg_log_loss',
+    'precision',
+    'precision_micro',
+    'precision_macro',
+    'precision_weighted',
+    'precision_samples',
+    'recall',
+    'recall_micro',
+    'recall_macro',
+    'recall_weighted',
+    'recall_samples',
+    'jaccard',
+    'jaccard_micro',
+    'jaccard_macro',
+    'jaccard_weighted',
+    'jaccard_samples',
+    'roc_auc',
+    'roc_auc_ovr',
+    'roc_auc_ovo',
+    'roc_auc_ovr_weighted',
+    'roc_auc_ovo_weighted'
+])
+
+regressionLibraryMetrics = set([
+    'explained_variance',
+    'max_error',
+    'neg_mean_absolute_error',
+    'neg_mean_squared_error',
+    'neg_root_mean_squared_error',
+    'neg_mean_squared_log_error',
+    'neg_median_absolute_error',
+    'r2',
+    'neg_mean_poisson_deviance',
+    'neg_mean_gamma_deviance',
+])
+
+
+def isValidMetrics(metrics: Union[None, str, callable], isClassifier: bool) -> bool:
+    if(metrics == None):
+        return True
+
+    if(isinstance(metrics, str)):
+        possibleMetrics = classificationLibraryMetrics if isClassifier else regressionLibraryMetrics
+
+        return metrics in possibleMetrics
+
+    try:
+        _ = make_scorer(metrics)
+        return True
+    except:
+        return False
+
+    return False

--- a/automl_models_generation.py
+++ b/automl_models_generation.py
@@ -4,23 +4,12 @@ from automl_models import classificationModels, regressionModels
 
 
 def generateModel(X, y, isClassification, metrics, verbose=True):
-
     models = classificationModels if isClassification else regressionModels
 
     if (metrics == None):
         scoring = 'accuracy' if isClassification else 'neg_root_mean_squared_error'
     else:
         scoring = metrics if isinstance(metrics, str) else make_scorer(metrics)
-
-    # if isClassification:
-    #     models = classificationModels
-    #     scoring = 'accuracy'
-    # else:
-    #     models = regressionModels
-    #     scoring = 'neg_root_mean_squared_error'
-
-    # if(metrics != None):
-    #     scoring = metrics
 
     finalModel = models[0]
 

--- a/automl_models_generation.py
+++ b/automl_models_generation.py
@@ -1,14 +1,26 @@
 from sklearn.model_selection import GridSearchCV
+from sklearn.metrics import make_scorer
 from automl_models import classificationModels, regressionModels
 
 
-def generateModel(X, y, isClassification, verbose=True):
-    if isClassification:
-        models = classificationModels
-        scoring = 'accuracy'
+def generateModel(X, y, isClassification, metrics, verbose=True):
+
+    models = classificationModels if isClassification else regressionModels
+
+    if (metrics == None):
+        scoring = 'accuracy' if isClassification else 'neg_root_mean_squared_error'
     else:
-        models = regressionModels
-        scoring = 'neg_root_mean_squared_error'
+        scoring = metrics if isinstance(metrics, str) else make_scorer(metrics)
+
+    # if isClassification:
+    #     models = classificationModels
+    #     scoring = 'accuracy'
+    # else:
+    #     models = regressionModels
+    #     scoring = 'neg_root_mean_squared_error'
+
+    # if(metrics != None):
+    #     scoring = metrics
 
     finalModel = models[0]
 

--- a/automl_models_generation.py
+++ b/automl_models_generation.py
@@ -4,13 +4,12 @@ from automl_models import classificationModels, regressionModels
 
 
 def generateModel(X, y, isClassification, metrics, verbose=True):
-    models = classificationModels if isClassification else regressionModels
-
     if (metrics == None):
         scoring = 'accuracy' if isClassification else 'neg_root_mean_squared_error'
     else:
         scoring = metrics if isinstance(metrics, str) else make_scorer(metrics)
 
+    models = classificationModels if isClassification else regressionModels
     finalModel = models[0]
 
     for model in models:


### PR DESCRIPTION
Add metrics selection to the interface. User may select his own metrics when calling `learn`, `learnAndPredict` or `learnFromDf` function. Metrics may be either a *text* containing basic metrics supported by **scikit-learn** library, described [here](https://scikit-learn.org/stable/modules/model_evaluation.html), or make his own scoring function. 

The scoring function must receive **two arguments** - list of **real** labels and a list of **predicted** labels. The returned value must be a number. Library expects **greater** scores to be **better**. 